### PR TITLE
Add moveTo operation for component utilities

### DIFF
--- a/lib/cju.ts
+++ b/lib/cju.ts
@@ -7,6 +7,7 @@ import type {
 import * as Soup from "circuit-json"
 import type { SubtreeOptions } from "./subtree"
 import { buildSubtree } from "./subtree"
+import { getElementPosition, setElementPosition } from "./get-element-position"
 
 export type CircuitJsonOps<
   K extends AnyCircuitElement["type"],
@@ -25,6 +26,10 @@ export type CircuitJsonOps<
     id: string,
     newProps: Partial<Extract<T, { type: K }>>,
   ) => Extract<T, { type: K }>
+  moveTo: (
+    id: string,
+    pos: { x: number; y: number },
+  ) => Extract<T, { type: K }> | null
   delete: (id: string) => void
   list: (where?: any) => Extract<T, { type: K }>[]
 }
@@ -185,6 +190,47 @@ export const cju: GetCircuitJsonUtilFn = ((
             if (!elm) return null
             Object.assign(elm, newProps)
             internalStore.editCount++
+            return elm
+          },
+          moveTo: (id: string, pos: { x: number; y: number }) => {
+            const elm = circuitJson.find(
+              (e) =>
+                e.type === component_type &&
+                (e as any)[`${component_type}_id`] === id,
+            ) as Extract<T, { type: K }> | undefined
+            if (!elm) return null
+            const cur = getElementPosition(elm as any)
+            if (cur) {
+              const dx = pos.x - cur.x
+              const dy = pos.y - cur.y
+              setElementPosition(elm as any, pos)
+              if (component_type === "schematic_component") {
+                for (const ce of circuitJson) {
+                  if (
+                    ce.type === "schematic_port" &&
+                    (ce as any).schematic_component_id === id
+                  ) {
+                    const cp = getElementPosition(ce)
+                    if (cp)
+                      setElementPosition(ce, {
+                        x: cp.x + dx,
+                        y: cp.y + dy,
+                      })
+                  } else if (
+                    ce.type === "schematic_text" &&
+                    (ce as any).schematic_component_id === id
+                  ) {
+                    const cp = getElementPosition(ce)
+                    if (cp)
+                      setElementPosition(ce, {
+                        x: cp.x + dx,
+                        y: cp.y + dy,
+                      })
+                  }
+                }
+              }
+              internalStore.editCount++
+            }
             return elm
           },
           select: (selector: string) => {

--- a/lib/get-element-position.ts
+++ b/lib/get-element-position.ts
@@ -1,0 +1,51 @@
+import type { AnyCircuitElement } from "circuit-json"
+
+export const getElementPosition = (
+  elm: AnyCircuitElement,
+): { x: number; y: number } | null => {
+  if (
+    "center" in elm &&
+    (elm as any).center &&
+    typeof (elm as any).center.x === "number" &&
+    typeof (elm as any).center.y === "number"
+  ) {
+    return { x: (elm as any).center.x, y: (elm as any).center.y }
+  }
+
+  if (
+    "position" in elm &&
+    (elm as any).position &&
+    typeof (elm as any).position.x === "number" &&
+    typeof (elm as any).position.y === "number"
+  ) {
+    return { x: (elm as any).position.x, y: (elm as any).position.y }
+  }
+
+  if ("x" in elm && "y" in elm) {
+    return { x: (elm as any).x, y: (elm as any).y }
+  }
+
+  return null
+}
+
+export const setElementPosition = (
+  elm: AnyCircuitElement,
+  pos: { x: number; y: number },
+): void => {
+  if ("center" in elm && (elm as any).center) {
+    ;(elm as any).center.x = pos.x
+    ;(elm as any).center.y = pos.y
+    return
+  }
+
+  if ("position" in elm && (elm as any).position) {
+    ;(elm as any).position.x = pos.x
+    ;(elm as any).position.y = pos.y
+    return
+  }
+
+  if ("x" in elm && "y" in elm) {
+    ;(elm as any).x = pos.x
+    ;(elm as any).y = pos.y
+  }
+}

--- a/tests/move-to.test.ts
+++ b/tests/move-to.test.ts
@@ -1,0 +1,51 @@
+import type { AnyCircuitElement } from "circuit-json"
+import { cju } from "../index"
+import { test, expect } from "bun:test"
+
+test("move schematic component", () => {
+  const soup: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "src1",
+      name: "SC",
+    },
+    {
+      type: "source_port",
+      source_port_id: "sp1",
+      source_component_id: "src1",
+      name: "p1",
+    },
+    {
+      type: "schematic_component",
+      schematic_component_id: "sc1",
+      source_component_id: "src1",
+      size: { width: 1, height: 1 },
+      center: { x: 0, y: 0 },
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "scp1",
+      source_port_id: "sp1",
+      schematic_component_id: "sc1",
+      center: { x: 1, y: 0 },
+    },
+    {
+      type: "schematic_text",
+      schematic_text_id: "st1",
+      schematic_component_id: "sc1",
+      text: "hi",
+      position: { x: 0, y: -1 },
+      rotation: 0,
+    },
+  ]
+
+  cju(soup).schematic_component.moveTo("sc1", { x: 5, y: 5 })
+
+  const sc = cju(soup).schematic_component.get("sc1")!
+  const sp = cju(soup).schematic_port.get("scp1")!
+  const st = cju(soup).schematic_text.get("st1")!
+
+  expect(sc.center).toEqual({ x: 5, y: 5 })
+  expect(sp.center).toEqual({ x: 6, y: 5 })
+  expect(st.position).toEqual({ x: 5, y: 4 })
+})


### PR DESCRIPTION
## Summary
- extend utility operations with a `moveTo` method
- update indexed version to support `moveTo`
- add helper to get/set element positions
- test moving schematic components and their children

## Testing
- `npx biome lint lib/cju.ts lib/cju-indexed.ts lib/get-element-position.ts tests/move-to.test.ts`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_683df84863c4832e8269ba0b42f0c5ae