### PR TITLE
Test cutout rotation with circuit json

### DIFF
--- a/lib/transform-soup-elements.ts
+++ b/lib/transform-soup-elements.ts
@@ -67,8 +67,17 @@ export const transformPCBElement = (elm: AnyCircuitElement, matrix: Matrix) => {
     ;(elm as any).x = x
     ;(elm as any).y = y
   } else if (elm.type === "pcb_keepout" || elm.type === "pcb_board") {
-    // TODO adjust size/rotation
+    // Rotate the keepout / board outline centre point
     elm.center = applyToPoint(matrix, elm.center)
+
+    // When the rotation is an odd multiple of 90° the width/height should be swapped
+    if (flipPadWidthHeight) {
+      // Only swap when both dimensions exist on the element (keeps backwards-compatibility)
+      if ("width" in elm && "height" in elm) {
+        // @ts-ignore – runtime check guarantees properties exist
+        ;[elm.width, elm.height] = [elm.height as number, elm.width as number]
+      }
+    }
   } else if (
     elm.type === "pcb_silkscreen_text" ||
     elm.type === "pcb_fabrication_note_text"

--- a/tests/transform-pcb-cutout-rotation.test.ts
+++ b/tests/transform-pcb-cutout-rotation.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "bun:test"
+import { rotateDEG } from "transformation-matrix"
+import { transformPCBElements } from "../lib/transform-soup-elements"
+import { runTscircuitCode } from "tscircuit"
+
+// This test reproduces the bug where rectangular board cutouts (pcb_keepout)
+// did not have their width/height swapped when the board was rotated by 90°.
+// The fix in `transform-soup-elements.ts` now ensures the dimensions are
+// updated correctly.
+
+test("transformPCBElements rotates pcb_keepout width/height on 90° rotation", async () => {
+  const circuitJson = await runTscircuitCode(`
+
+export default () => (
+  <board>
+    <jumper name="J1" footprint="m2host" />
+  </board>
+)
+  `)
+
+  // Extract the pcb_keepout elements produced by the m2host footprint.
+  const keepouts = circuitJson.filter((e: any) => e.type === "pcb_keepout")
+  expect(keepouts.length).toBeGreaterThan(0)
+
+  // Capture the original dimensions so we can compare after rotation.
+  const originalDims = keepouts.map((k: any) => ({ width: k.width, height: k.height }))
+
+  // Apply a 90° rotation.
+  transformPCBElements(circuitJson as any, rotateDEG(90))
+
+  keepouts.forEach((k: any, idx: number) => {
+    expect(k.width).toBeCloseTo(originalDims[idx].height)
+    expect(k.height).toBeCloseTo(originalDims[idx].width)
+  })
+})


### PR DESCRIPTION
Fixes `pcb_keepout` and `pcb_board` dimensions not rotating correctly with `transformPCBElements`.

Previously, `pcb_keepout` and `pcb_board` elements did not have their `width` and `height` swapped when rotated by an odd multiple of 90 degrees. This PR adds logic to correctly swap these dimensions during `transformPCBElements` and includes a new test to prevent regressions.

---

[Open in Web](https://cursor.com/agents?id=bc-65868d5c-8bc8-496f-9670-7b0fa8ae88b1) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-65868d5c-8bc8-496f-9670-7b0fa8ae88b1) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)