### PR TITLE
Fix pcb_cutout rotation handling

### DIFF
--- a/lib/transform-soup-elements.ts
+++ b/lib/transform-soup-elements.ts
@@ -106,6 +106,22 @@ export const transformPCBElement = (elm: AnyCircuitElement, matrix: Matrix) => {
     elm.y1 = p1t.y
     elm.x2 = p2t.x
     elm.y2 = p2t.y
+  } else if (elm.type === "pcb_cutout") {
+    elm.center = applyToPoint(matrix, elm.center)
+    if (elm.shape === "polygon") {
+      elm.points = elm.points.map((p) => {
+        const tp = applyToPoint(matrix, p) as { x: number; y: number }
+        p.x = tp.x
+        p.y = tp.y
+        return p
+      })
+    } else if (elm.shape === "rect" && flipPadWidthHeight) {
+      ;[elm.width, elm.height] = [elm.height, elm.width]
+    }
+    if (typeof elm.rotation === "number") {
+      elm.rotation = elm.rotation + (tsr.rotation.angle / Math.PI) * 180
+      elm.rotation = elm.rotation % 360
+    }
   } else if (elm.type === "cad_component") {
     const newPos = applyToPoint(matrix, {
       x: elm.position.x,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "esbuild": "^0.20.2",
     "esbuild-register": "^3.5.0",
     "transformation-matrix": "^2.16.1",
-    "tscircuit": "^0.0.562",
+    "tscircuit": "^0.0.567",
     "tsup": "^8.0.2",
     "typescript": "^5.4.5",
     "zod": "^3.23.6"

--- a/tests/transform-pcb-cutout.test.ts
+++ b/tests/transform-pcb-cutout.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "bun:test"
+import { rotate } from "transformation-matrix"
+import { transformPCBElements } from "../lib/transform-soup-elements"
+import { runTscircuitCode } from "tscircuit"
+
+// regression test for pcb_cutout rotation
+
+test("transformPCBElements rotates pcb_cutout width/height", async () => {
+  const circuitJson = await runTscircuitCode(`
+export default () => (
+  <board>
+    <jumper name="J1" footprint="m2host" />
+  </board>
+)
+`)
+  const cutout = circuitJson.find(
+    (e) => e.type === "pcb_cutout" && (e as any).shape === "rect",
+  ) as any
+  expect(cutout).toBeTruthy()
+  const originalWidth = cutout.width
+  const originalHeight = cutout.height
+
+  transformPCBElements([cutout], rotate(Math.PI / 2))
+
+  expect(cutout.width).toBeCloseTo(originalHeight)
+  expect(cutout.height).toBeCloseTo(originalWidth)
+})


### PR DESCRIPTION
## Summary
- update `tscircuit` to latest
- rotate rectangular cutouts in `transformPCBElement`
- add regression test covering pcb cutout rotation

## Testing
- `bun test tests/transform-pcb-cutout.test.ts`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_6887ee5836c8832e95c56fd5e5c5ea30