### PR TITLE
feat: add minimum flex container util

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,7 @@ export * from "./lib/reposition-pcb-component"
 export * from "./lib/reposition-pcb-group"
 export * from "./lib/getCircuitJsonTree"
 export * from "./lib/getStringFromCircuitJsonTree"
+export * from "./lib/get-minimum-flex-container"
 
 export {
   transformPCBElement as transformPcbElement,

--- a/lib/get-minimum-flex-container.ts
+++ b/lib/get-minimum-flex-container.ts
@@ -1,0 +1,54 @@
+export type Size = { width: number; height: number }
+
+/**
+ * Options for flex container sizing. This mirrors the subset of
+ * `@tscircuit/miniflex` options used by `getMinimumFlexContainer`.
+ */
+export interface FlexBoxOptions {
+  direction?: "row" | "row-reverse" | "column" | "column-reverse"
+  columnGap?: number
+  rowGap?: number
+}
+
+/**
+ * Compute the smallest possible dimensions (width & height) for a flex container
+ * so that **all** children fit without overflowing _before_ any flex grow / shrink
+ * is applied. This is a very lightweight approximation – it only considers the
+ * children's explicit `width`/`height` (or `flexBasis`) plus the configured gaps
+ * and the main-axis stacking rules derived from the flex direction.
+ *
+ * This function purposely does **not** try to implement the full flexbox sizing
+ * algorithm – we only need a quick estimate so that `RootFlexBox` can be
+ * instantiated even when the user did not provide explicit dimensions for the
+ * container (e.g. when laying out PCB components directly on the board level
+ * instead of inside a sub-circuit).
+ */
+export function getMinimumFlexContainer(
+  children: Array<{ width: number; height: number }>,
+  options: FlexBoxOptions = {},
+): Size {
+  if (children.length === 0) return { width: 0, height: 0 }
+
+  const direction = options.direction ?? "row"
+  const columnGap = options.columnGap ?? 0
+  const rowGap = options.rowGap ?? 0
+
+  // Flexbox main-axis / cross-axis mapping --------------------------------
+  const isRowDirection = direction === "row" || direction === "row-reverse"
+
+  if (isRowDirection) {
+    // Main-axis horizontally stacks children
+    const totalChildWidth = children.reduce((sum, c) => sum + c.width, 0)
+    const width = totalChildWidth + columnGap * Math.max(0, children.length - 1)
+
+    const height = children.reduce((max, c) => Math.max(max, c.height), 0)
+    return { width, height }
+  } else {
+    // Column direction – stack vertically
+    const totalChildHeight = children.reduce((sum, c) => sum + c.height, 0)
+    const height = totalChildHeight + rowGap * Math.max(0, children.length - 1)
+
+    const width = children.reduce((max, c) => Math.max(max, c.width), 0)
+    return { width, height }
+  }
+}

--- a/tests/get-minimum-flex-container.test.ts
+++ b/tests/get-minimum-flex-container.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { getMinimumFlexContainer } from "../lib/get-minimum-flex-container"
+
+test("getMinimumFlexContainer computes correct size for row direction", () => {
+  const children = [
+    { width: 10, height: 5 },
+    { width: 20, height: 7 },
+  ]
+  const { width, height } = getMinimumFlexContainer(children, {
+    direction: "row",
+  })
+
+  expect(width).toBe(30)
+  expect(height).toBe(7)
+})
+
+test("getMinimumFlexContainer computes correct size for column direction", () => {
+  const children = [
+    { width: 10, height: 5 },
+    { width: 20, height: 7 },
+  ]
+  const { width, height } = getMinimumFlexContainer(children, {
+    direction: "column",
+  })
+
+  expect(width).toBe(20)
+  expect(height).toBe(12)
+})


### PR DESCRIPTION
## Summary
- add getMinimumFlexContainer utility to compute minimal flexbox container size
- export getMinimumFlexContainer from library index
- test container sizing for row and column directions

## Testing
- `npx @biomejs/biome lint .` *(fails: noUnreachable, noParameterAssign, noBannedTypes, and others)*
- `bun test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68976684c590832799d8fd0d3ca21ef8