### PR TITLE
Export shape-distance helper methods from public API

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,7 @@ export * from "./lib/get-minimum-flex-container"
 export * from "./lib/get-element-render-layers"
 export * from "./lib/compute-gap-between-copper"
 export * from "./lib/compute-clearance-between-elements"
+export * from "./lib/shape-distances/distance-between-shapes"
 
 export {
   transformPCBElement as transformPcbElement,

--- a/lib/shape-distances/distance-between-shapes.ts
+++ b/lib/shape-distances/distance-between-shapes.ts
@@ -7,10 +7,10 @@ import {
 } from "./geometry"
 import type { Circle, CopperShape, Polygon, Rect } from "./types"
 
-const distanceBetweenCircleAndCircle = (a: Circle, b: Circle) =>
+export const distanceBetweenCircleAndCircle = (a: Circle, b: Circle) =>
   Math.max(0, Math.hypot(a.x - b.x, a.y - b.y) - a.radius - b.radius)
 
-const distanceBetweenPolygonAndPolygon = (a: Polygon, b: Polygon) => {
+export const distanceBetweenPolygonAndPolygon = (a: Polygon, b: Polygon) => {
   if (a.points.length < 3 || b.points.length < 3) {
     return Number.POSITIVE_INFINITY
   }
@@ -49,7 +49,10 @@ const distanceBetweenPolygonAndPolygon = (a: Polygon, b: Polygon) => {
   return minDistance
 }
 
-const distanceBetweenCircleAndPolygon = (circle: Circle, polygon: Polygon) => {
+export const distanceBetweenCircleAndPolygon = (
+  circle: Circle,
+  polygon: Polygon,
+) => {
   if (polygon.points.length < 3) {
     return Number.POSITIVE_INFINITY
   }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "type": "module",
   "version": "0.0.92",
   "description": "Utility library for working with tscircuit circuit json",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "main": "dist/index.js",
   "scripts": {
     "test": "bun test",


### PR DESCRIPTION
### Motivation
- Allow other libraries to import the internal shape-distance helper functions from the package public API so they can reuse those calculations.

### Description
- Exported `distanceBetweenCircleAndCircle`, `distanceBetweenPolygonAndPolygon`, and `distanceBetweenCircleAndPolygon` from `lib/shape-distances/distance-between-shapes.ts`.
- Re-exported the module at the package root by adding `export * from "./lib/shape-distances/distance-between-shapes"` to `index.ts` so consumers can import these helpers from `@tscircuit/circuit-json-util`.

### Testing
- Ran `bun test`, which executed 71 tests across 32 files and completed successfully with all tests passing (71 pass, 0 fail).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e3fce3a9588327b6c772877dc104da)