### PR TITLE
Transform pcb_component insertion metadata in transformPCBElements

### DIFF
--- a/lib/transform-soup-elements.ts
+++ b/lib/transform-soup-elements.ts
@@ -6,6 +6,70 @@ import {
   vecToDirection,
 } from "./direction-to-vec"
 
+type PcbInsertionDirection =
+  | "from_above"
+  | "from_left"
+  | "from_right"
+  | "from_front"
+  | "from_back"
+
+const getQuarterTurns = (angleRadians: number) =>
+  Math.round(angleRadians / (Math.PI / 2))
+
+const insertionDirectionToVec = (
+  direction: Exclude<PcbInsertionDirection, "from_above">,
+) => {
+  switch (direction) {
+    case "from_left":
+      return { x: -1, y: 0 }
+    case "from_right":
+      return { x: 1, y: 0 }
+    case "from_front":
+      return { x: 0, y: 1 }
+    case "from_back":
+      return { x: 0, y: -1 }
+  }
+}
+
+const vecToInsertionDirection = ({
+  x,
+  y,
+}: {
+  x: number
+  y: number
+}): Exclude<PcbInsertionDirection, "from_above"> => {
+  if (x > 0) return "from_right"
+  if (x < 0) return "from_left"
+  if (y > 0) return "from_front"
+  return "from_back"
+}
+
+export const transformInsertionDirection = (
+  direction: PcbInsertionDirection | undefined,
+  opts: { rotationDegrees: number; isFlipped: boolean },
+) => {
+  if (!direction || direction === "from_above") return direction
+
+  let { x, y } = insertionDirectionToVec(direction)
+  let quarterTurns = Math.round(opts.rotationDegrees / 90)
+
+  while (quarterTurns > 0) {
+    ;[x, y] = [-y, x]
+    quarterTurns--
+  }
+
+  while (quarterTurns < 0) {
+    ;[x, y] = [y, -x]
+    quarterTurns++
+  }
+
+  if (opts.isFlipped) {
+    y = -y
+  }
+
+  return vecToInsertionDirection({ x, y })
+}
+
 export const transformSchematicElement = (
   elm: AnyCircuitElement,
   matrix: Matrix,
@@ -74,7 +138,9 @@ export const transformSchematicElements = (
 export const transformPCBElement = (elm: AnyCircuitElement, matrix: Matrix) => {
   const tsr = decomposeTSR(matrix)
   const flipPadWidthHeight =
-    Math.round(tsr.rotation.angle / (Math.PI / 2)) % 2 === 1
+    Math.abs(getQuarterTurns(tsr.rotation.angle)) % 2 === 1
+  const rotationDegrees = (tsr.rotation.angle / Math.PI) * 180
+  const isFlipped = tsr.scale.sy < 0
   if (
     elm.type === "pcb_plated_hole" ||
     elm.type === "pcb_hole" ||
@@ -122,8 +188,21 @@ export const transformPCBElement = (elm: AnyCircuitElement, matrix: Matrix) => {
     elm.center = applyToPoint(matrix, elm.center)
   } else if (elm.type === "pcb_component") {
     elm.center = applyToPoint(matrix, elm.center)
-    elm.rotation = elm.rotation + (tsr.rotation.angle / Math.PI) * 180
+    elm.rotation = elm.rotation + rotationDegrees
     elm.rotation = elm.rotation % 360
+    if (elm.cable_insertion_center) {
+      elm.cable_insertion_center = applyToPoint(
+        matrix,
+        elm.cable_insertion_center,
+      )
+    }
+    elm.insertion_direction = transformInsertionDirection(
+      elm.insertion_direction,
+      {
+        rotationDegrees,
+        isFlipped,
+      },
+    )
     if (flipPadWidthHeight) {
       ;[elm.width, elm.height] = [elm.height, elm.width]
     }
@@ -181,7 +260,7 @@ export const transformPCBElements = (
   matrix: Matrix,
 ) => {
   const tsr = decomposeTSR(matrix)
-  const quarterTurns = Math.round(tsr.rotation.angle / (Math.PI / 2))
+  const quarterTurns = getQuarterTurns(tsr.rotation.angle)
   const flipPadWidthHeight = Math.abs(quarterTurns) % 2 === 1
   let transformedElms = elms.map((elm) => transformPCBElement(elm, matrix))
   if (flipPadWidthHeight) {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "type": "module",
   "version": "0.0.93",
   "description": "Utility library for working with tscircuit circuit json",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "main": "dist/index.js",
   "scripts": {
     "test": "bun test",
@@ -27,7 +25,7 @@
     "@biomejs/biome": "^1.9.2",
     "@tscircuit/miniflex": "^0.0.4",
     "@types/bun": "^1.2.9",
-    "circuit-json": "^0.0.407",
+    "circuit-json": "^0.0.418",
     "esbuild": "^0.20.2",
     "esbuild-register": "^3.5.0",
     "transformation-matrix": "^2.16.1",

--- a/tests/transform-pcb-elements.test.ts
+++ b/tests/transform-pcb-elements.test.ts
@@ -1,7 +1,22 @@
 import { expect, test } from "bun:test"
-import { translate } from "transformation-matrix"
-import type { AnyCircuitElement } from "circuit-json"
+import { compose, rotateDEG, scale, translate } from "transformation-matrix"
+import type { AnyCircuitElement, PcbComponent } from "circuit-json"
 import { transformPCBElements } from "../lib/transform-soup-elements"
+
+const createPcbComponent = (
+  overrides: Partial<Record<string, unknown>> = {},
+): AnyCircuitElement => ({
+  type: "pcb_component",
+  pcb_component_id: "pc1",
+  source_component_id: "sc1",
+  layer: "top",
+  center: { x: 1, y: 2 },
+  width: 4,
+  height: 2,
+  rotation: 0,
+  obstructs_within_bounds: true,
+  ...overrides,
+})
 
 test("transformPCBElements moves pcb_silkscreen_path route", () => {
   const elms: AnyCircuitElement[] = [
@@ -189,4 +204,77 @@ test("transformPCBElements moves pcb_note_line x1,y1,x2,y2", () => {
   expect(line.y1).toBe(4)
   expect(line.x2).toBe(8)
   expect(line.y2).toBe(9)
+})
+
+test("transformPCBElements rotates pcb_component insertion_direction for 90/180/270 degree transforms", () => {
+  const cases = [
+    { rotationDegrees: 90, expectedDirection: "from_front" },
+    { rotationDegrees: 180, expectedDirection: "from_left" },
+    { rotationDegrees: 270, expectedDirection: "from_back" },
+  ] as const
+
+  for (const { rotationDegrees, expectedDirection } of cases) {
+    const elms: AnyCircuitElement[] = [
+      createPcbComponent({ insertion_direction: "from_right" }),
+    ]
+
+    transformPCBElements(elms, compose(rotateDEG(rotationDegrees)))
+
+    const component = elms[0] as PcbComponent
+    expect(component).toBeDefined()
+    if (component) expect(component.insertion_direction).toBe(expectedDirection)
+  }
+})
+
+test("transformPCBElements mirrors pcb_component insertion_direction for flipped transforms", () => {
+  const elms: AnyCircuitElement[] = [
+    createPcbComponent({
+      pcb_component_id: "pc-front",
+      insertion_direction: "from_front",
+    }),
+    createPcbComponent({
+      pcb_component_id: "pc-left",
+      insertion_direction: "from_left",
+    }),
+  ]
+
+  transformPCBElements(elms, compose(scale(1, -1)))
+
+  expect((elms[0] as PcbComponent).insertion_direction).toBe("from_back")
+  expect((elms[1] as PcbComponent).insertion_direction).toBe("from_left")
+})
+
+test("transformPCBElements applies rotation before Y-mirror for pcb_component insertion_direction", () => {
+  const elms: AnyCircuitElement[] = [
+    createPcbComponent({ insertion_direction: "from_left" }),
+  ]
+
+  transformPCBElements(elms, compose(scale(1, -1), rotateDEG(90)))
+
+  expect((elms[0] as PcbComponent).insertion_direction).toBe("from_front")
+})
+
+test('transformPCBElements keeps pcb_component insertion_direction "from_above" unchanged', () => {
+  const elms: AnyCircuitElement[] = [
+    createPcbComponent({ insertion_direction: "from_above" }),
+  ]
+
+  transformPCBElements(elms, compose(scale(1, -1), rotateDEG(90)))
+
+  expect((elms[0] as PcbComponent).insertion_direction).toBe("from_above")
+})
+
+test("transformPCBElements moves pcb_component cable_insertion_center", () => {
+  const elms: AnyCircuitElement[] = [
+    createPcbComponent({
+      cable_insertion_center: { x: 3, y: 4 },
+    }),
+  ]
+
+  transformPCBElements(elms, translate(5, 6))
+
+  expect((elms[0] as PcbComponent).cable_insertion_center).toEqual({
+    x: 8,
+    y: 10,
+  })
 })


### PR DESCRIPTION
Update transformPCBElement to keep pcb_component geometric metadata consistent by transforming insertion_direction from matrix rotation plus PCB-space Y flip, and by moving cable_insertion_center with the applied matrix. This also switches quarter-turn handling to use absolute parity so width/height swaps stay correct for negative rotations as well.