### PR TITLE
Fix findBoundsAndCenter for circular_hole_with_rect_pad plated holes

### DIFF
--- a/lib/utils/get-layout-debug-object.ts
+++ b/lib/utils/get-layout-debug-object.ts
@@ -166,6 +166,16 @@ export const getDebugLayoutObject = (lo: any): LayoutDebugObject | null => {
     if ("outer_diameter" in lo) {
       width = lo.outer_diameter
       height = lo.outer_diameter
+    } else if ("rect_pad_width" in lo && "rect_pad_height" in lo) {
+      width = lo.rect_pad_width as number
+      height = lo.rect_pad_height as number
+      if ("hole_diameter" in lo) {
+        width = Math.max(width, lo.hole_diameter as number)
+        height = Math.max(height, lo.hole_diameter as number)
+      }
+    } else if ("hole_diameter" in lo) {
+      width = lo.hole_diameter
+      height = lo.hole_diameter
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "type": "module",
   "version": "0.0.94",
   "description": "Utility library for working with tscircuit circuit json",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "main": "dist/index.js",
   "scripts": {
     "test": "bun test",

--- a/tests/find-bounds-and-center.test.ts
+++ b/tests/find-bounds-and-center.test.ts
@@ -75,6 +75,56 @@ test("should handle pcb_trace elements correctly", () => {
   })
 })
 
+test("should handle circular_hole_with_rect_pad plated hole correctly", () => {
+  const elements = [
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "pcb_plated_hole_0",
+      x: 0,
+      y: 0,
+      shape: "circular_hole_with_rect_pad",
+      hole_diameter: 1,
+      rect_pad_width: 1.5,
+      rect_pad_height: 1.5,
+      hole_offset_x: 0,
+      hole_offset_y: 0,
+      rect_ccw_rotation: 0,
+      layers: ["top", "bottom"],
+    } as AnyCircuitElement,
+  ]
+  const result = findBoundsAndCenter(elements as unknown as AnyCircuitElement[])
+  expect(result).toEqual({
+    center: { x: 0, y: 0 },
+    width: 1.5,
+    height: 1.5,
+  })
+})
+
+test("should handle circular_hole_with_rect_pad where hole is larger than pad", () => {
+  const elements = [
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "pcb_plated_hole_1",
+      x: 5,
+      y: 5,
+      shape: "circular_hole_with_rect_pad",
+      hole_diameter: 3,
+      rect_pad_width: 2,
+      rect_pad_height: 2,
+      hole_offset_x: 0,
+      hole_offset_y: 0,
+      rect_ccw_rotation: 0,
+      layers: ["top", "bottom"],
+    } as unknown as AnyCircuitElement,
+  ]
+  const result = findBoundsAndCenter(elements as unknown as AnyCircuitElement[])
+  expect(result).toEqual({
+    center: { x: 5, y: 5 },
+    width: 3,
+    height: 3,
+  })
+})
+
 test("should handle polygon SMT pad elements correctly", () => {
   const elements = [
     {


### PR DESCRIPTION
`getDebugLayoutObject` didn't recognize `rect_pad_width`/`rect_pad_height` or `hole_diameter` properties, causing `findBoundsAndCenter` to fall back to 0.1x0.1 bounds for `circular_hole_with_rect_pad` pads. Added handling for these properties so bounds are computed correctly.