### PR TITLE
fix: smtpad pill shape rotation

### DIFF
--- a/lib/transform-soup-elements.ts
+++ b/lib/transform-soup-elements.ts
@@ -267,7 +267,10 @@ export const transformPCBElements = (
   let transformedElms = elms.map((elm) => transformPCBElement(elm, matrix))
   if (flipPadWidthHeight) {
     transformedElms = transformedElms.map((elm) => {
-      if (elm.type === "pcb_smtpad" && elm.shape === "rect") {
+      if (
+        elm.type === "pcb_smtpad" &&
+        (elm.shape === "rect" || elm.shape === "pill")
+      ) {
         ;[elm.width, elm.height] = [elm.height, elm.width]
       }
       return elm

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "type": "module",
   "version": "0.0.96",
   "description": "Utility library for working with tscircuit circuit json",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "main": "dist/index.js",
   "scripts": {
     "test": "bun test",

--- a/tests/transform-pcb-elements.test.ts
+++ b/tests/transform-pcb-elements.test.ts
@@ -141,6 +141,33 @@ test("transformPCBElements rotates pcb_courtyard_rect ccw_rotation", () => {
   expect(rect.ccw_rotation).toBe(135)
 })
 
+test("transformPCBElements swaps pill smtpad dimensions for 90 degree transforms", () => {
+  const elms: AnyCircuitElement[] = [
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      pcb_component_id: "pc1",
+      pcb_port_id: "port1",
+      layer: "top",
+      shape: "pill",
+      x: 1,
+      y: 0,
+      width: 0.3,
+      height: 1.5,
+      radius: 0.15,
+    } as any,
+  ]
+
+  transformPCBElements(elms, compose(translate(10, 20), rotateDEG(90)))
+
+  const pad = elms[0] as any
+  expect(pad.x).toBeCloseTo(10)
+  expect(pad.y).toBeCloseTo(21)
+  expect(pad.width).toBe(1.5)
+  expect(pad.height).toBe(0.3)
+  expect(pad.radius).toBe(0.15)
+})
+
 test("transformPCBElements moves pcb_courtyard_circle center", () => {
   const elms: AnyCircuitElement[] = [
     {


### PR DESCRIPTION
## BEFORE

<img width="748" height="682" alt="image" src="https://github.com/user-attachments/assets/7dccbb0f-c3e4-4e39-8831-0d9a9ae35b99" />


## AFTER

<img width="508" height="548" alt="image" src="https://github.com/user-attachments/assets/9b42e59e-be21-4538-bee3-6fc5731349ab" />

