### PR TITLE
Fix vecToDirection throwing on down and left vectors

### DIFF
--- a/lib/direction-to-vec.ts
+++ b/lib/direction-to-vec.ts
@@ -7,8 +7,8 @@ export const directionToVec = (direction: "up" | "down" | "left" | "right") => {
 }
 
 export const vecToDirection = ({ x, y }: { x: number; y: number }) => {
-  if (x > y) y = 0
-  if (y > x) x = 0
+  if (Math.abs(x) > Math.abs(y)) y = 0
+  else if (Math.abs(y) > Math.abs(x)) x = 0
   if (x > 0 && y === 0) return "right"
   else if (x < 0 && y === 0) return "left"
   else if (x === 0 && y > 0) return "up"

--- a/tests/direction-to-vec.test.ts
+++ b/tests/direction-to-vec.test.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "bun:test"
+import { directionToVec, vecToDirection } from "../lib/direction-to-vec"
+
+test("vecToDirection round-trips all four directions", () => {
+  const directions = ["up", "down", "left", "right"] as const
+  for (const dir of directions) {
+    expect(vecToDirection(directionToVec(dir))).toBe(dir)
+  }
+})


### PR DESCRIPTION
vecToDirection zeroed both axes for negative-axis unit vectors because it compared raw signs instead of magnitudes, so directionToVec("down") and directionToVec("left") didn't round-trip — they threw "Invalid vector". Compare magnitudes instead, and add a round-trip test for all four directions.