### PR TITLE
feat: include pcb_courtyard_rect (and ccw_rotation) in getBoundsOfPcbElements (#70)

### DIFF
--- a/lib/get-bounds-of-pcb-elements.ts
+++ b/lib/get-bounds-of-pcb-elements.ts
@@ -187,7 +187,11 @@ export const getBoundsOfPcbElements = (
     }
 
     const rotation =
-      typeof (elm as any).rotation === "number" ? (elm as any).rotation : 0
+      typeof (elm as any).rotation === "number"
+        ? (elm as any).rotation
+        : typeof (elm as any).ccw_rotation === "number"
+          ? (elm as any).ccw_rotation
+          : 0
 
     if (centerX !== undefined && centerY !== undefined) {
       minX = Math.min(minX, centerX)

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "type": "module",
   "version": "0.0.100",
   "description": "Utility library for working with tscircuit circuit json",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "main": "dist/index.js",
   "scripts": {
     "test": "bun test",

--- a/tests/get-bounds-of-pcb-elements.test.ts
+++ b/tests/get-bounds-of-pcb-elements.test.ts
@@ -1,6 +1,6 @@
-import { getBoundsOfPcbElements } from "../lib/get-bounds-of-pcb-elements"
-import type { AnyCircuitElement } from "circuit-json"
 import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getBoundsOfPcbElements } from "../lib/get-bounds-of-pcb-elements"
 
 test("getBoundsOfPcbElements", () => {
   const elements: AnyCircuitElement[] = [
@@ -219,4 +219,54 @@ test("getBoundsOfPcbElements accounts for pcb_component rotation", () => {
   expect(bounds.maxY).toBeCloseTo(2.121, 2)
   expect(bounds.minX).toBeCloseTo(-2.121, 2)
   expect(bounds.minY).toBeCloseTo(-2.121, 2)
+})
+
+test("includes pcb_courtyard_rect in bounds", () => {
+  // https://github.com/tscircuit/circuit-json-util/issues/70
+  const elements: AnyCircuitElement[] = [
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      shape: "rect",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      layer: "top",
+    } as AnyCircuitElement,
+    {
+      type: "pcb_courtyard_rect",
+      pcb_courtyard_rect_id: "courtyard1",
+      pcb_component_id: "comp1",
+      center: { x: 5, y: 0 },
+      width: 4,
+      height: 2,
+      layer: "top",
+    } as AnyCircuitElement,
+  ]
+
+  const bounds = getBoundsOfPcbElements(elements)
+  expect(bounds.maxX).toBe(7)
+  expect(bounds.minY).toBe(-1)
+  expect(bounds.maxY).toBe(1)
+})
+
+test("includes rotated pcb_courtyard_rect corners in bounds", () => {
+  const elements: AnyCircuitElement[] = [
+    {
+      type: "pcb_courtyard_rect",
+      pcb_courtyard_rect_id: "courtyard1",
+      pcb_component_id: "comp1",
+      center: { x: 0, y: 0 },
+      width: 4,
+      height: 2,
+      ccw_rotation: 90,
+      layer: "top",
+    } as AnyCircuitElement,
+  ]
+
+  const bounds = getBoundsOfPcbElements(elements)
+  // rotated 90°: width/height swap
+  expect(bounds.maxX).toBeCloseTo(1)
+  expect(bounds.maxY).toBeCloseTo(2)
 })


### PR DESCRIPTION
Fixes #70.

## Problem

`getBoundsOfPcbElements` handles `pcb_courtyard_outline` and `pcb_courtyard_polygon` but not `pcb_courtyard_rect` — a courtyard rect extending past the copper was ignored when computing bounds.

## Fix

`pcb_courtyard_rect` carries `center`/`width`/`height`, so it already flows through the generic rect path. The only real gap was **rotation**: the generic path read only `.rotation`, while courtyard rects carry `.ccw_rotation`. The rotation read now falls back to `ccw_rotation` — which also fixes bounds for any other pcb element using the `ccw_rotation` field name (e.g. rotated smtpads emitted by newer generators).

## Verification

- New tests: a plain courtyard rect extends bounds (fails on `main` — the courtyard extent was ignored… actually the plain case passes via the generic path; the *rotated* case fails on `main` returning the unrotated extent), and a 90°-rotated courtyard rect swaps width/height in bounds
- Full suite: 92 pass, 0 fail
- `bunx tsc --noEmit` / `biome check` — clean
