### PR TITLE
fix: transform pcb_solder_paste and other component-attached elements in transformPCBElement

### DIFF
--- a/lib/transform-soup-elements.ts
+++ b/lib/transform-soup-elements.ts
@@ -146,6 +146,7 @@ export const transformPCBElement = (elm: AnyCircuitElement, matrix: Matrix) => {
     elm.type === "pcb_hole" ||
     elm.type === "pcb_via" ||
     elm.type === "pcb_smtpad" ||
+    elm.type === "pcb_solder_paste" ||
     elm.type === "pcb_port"
   ) {
     const { x, y } = applyToPoint(matrix, {
@@ -178,12 +179,18 @@ export const transformPCBElement = (elm: AnyCircuitElement, matrix: Matrix) => {
     elm.type === "pcb_note_text"
   ) {
     elm.anchor_position = applyToPoint(matrix, elm.anchor_position)
+  } else if (elm.type === "pcb_copper_text") {
+    if (elm.anchor_position) {
+      elm.anchor_position = applyToPoint(matrix, elm.anchor_position)
+    }
   } else if (elm.type === "pcb_courtyard_rect") {
     elm.center = applyToPoint(matrix, elm.center)
     elm.ccw_rotation = ((elm.ccw_rotation ?? 0) + rotationDegrees) % 360
   } else if (
     elm.type === "pcb_silkscreen_circle" ||
     elm.type === "pcb_silkscreen_rect" ||
+    elm.type === "pcb_silkscreen_pill" ||
+    elm.type === "pcb_silkscreen_oval" ||
     elm.type === "pcb_note_rect" ||
     elm.type === "pcb_courtyard_circle"
   ) {
@@ -225,6 +232,7 @@ export const transformPCBElement = (elm: AnyCircuitElement, matrix: Matrix) => {
   } else if (
     elm.type === "pcb_silkscreen_path" ||
     elm.type === "pcb_trace" ||
+    elm.type === "pcb_trace_hint" ||
     elm.type === "pcb_fabrication_note_path" ||
     elm.type === "pcb_note_path"
   ) {
@@ -268,7 +276,7 @@ export const transformPCBElements = (
   if (flipPadWidthHeight) {
     transformedElms = transformedElms.map((elm) => {
       if (
-        elm.type === "pcb_smtpad" &&
+        (elm.type === "pcb_smtpad" || elm.type === "pcb_solder_paste") &&
         (elm.shape === "rect" || elm.shape === "pill")
       ) {
         ;[elm.width, elm.height] = [elm.height, elm.width]

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "type": "module",
   "version": "0.0.101",
   "description": "Utility library for working with tscircuit circuit json",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "main": "dist/index.js",
   "scripts": {
     "test": "bun test",

--- a/tests/reposition-pcb-component.test.ts
+++ b/tests/reposition-pcb-component.test.ts
@@ -70,3 +70,52 @@ test("repositionPcbComponentTo moves component and children", () => {
   expect(trace.route[1].x).toBe(15)
   expect(trace.route[1].y).toBe(5)
 })
+
+test("repositionPcbComponentTo moves solder paste with its pads (tscircuit/core#2897)", () => {
+  const soup: AnyCircuitElement[] = [
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 0, y: 0 },
+      layer: "top",
+      rotation: 0,
+      width: 2,
+      height: 2,
+    } as any,
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      pcb_component_id: "pc1",
+      x: -0.5,
+      y: 0,
+      width: 1,
+      height: 1,
+      layer: "top",
+      shape: "rect",
+    } as any,
+    {
+      type: "pcb_solder_paste",
+      pcb_solder_paste_id: "paste1",
+      pcb_component_id: "pc1",
+      pcb_smtpad_id: "pad1",
+      x: -0.5,
+      y: 0,
+      width: 0.7,
+      height: 0.7,
+      layer: "top",
+      shape: "rect",
+    } as any,
+  ]
+
+  repositionPcbComponentTo(soup, "pc1", { x: 10, y: 5 })
+
+  const pad = soup.find((e) => e.type === "pcb_smtpad") as any
+  const paste = soup.find((e) => e.type === "pcb_solder_paste") as any
+
+  expect(pad.x).toBe(9.5)
+  expect(pad.y).toBe(5)
+  // paste must stay aligned with its pad, not be left at the old position
+  expect(paste.x).toBe(9.5)
+  expect(paste.y).toBe(5)
+})

--- a/tests/transform-pcb-elements.test.ts
+++ b/tests/transform-pcb-elements.test.ts
@@ -327,3 +327,137 @@ test("transformPCBElements moves pcb_component cable_insertion_center", () => {
     y: 10,
   })
 })
+
+test("transformPCBElements moves pcb_solder_paste with its pad", () => {
+  const elms: AnyCircuitElement[] = [
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      pcb_component_id: "pc1",
+      layer: "top",
+      shape: "rect",
+      x: 1,
+      y: 2,
+      width: 1,
+      height: 0.5,
+    } as any,
+    {
+      type: "pcb_solder_paste",
+      pcb_solder_paste_id: "paste1",
+      pcb_component_id: "pc1",
+      pcb_smtpad_id: "pad1",
+      layer: "top",
+      shape: "rect",
+      x: 1,
+      y: 2,
+      width: 0.7,
+      height: 0.35,
+    } as any,
+  ]
+
+  transformPCBElements(elms, translate(5, 10))
+
+  const pad = elms[0] as any
+  const paste = elms[1] as any
+  expect(pad.x).toBe(6)
+  expect(pad.y).toBe(12)
+  expect(paste.x).toBe(6)
+  expect(paste.y).toBe(12)
+})
+
+test("transformPCBElements swaps rect pcb_solder_paste dimensions for 90 degree transforms", () => {
+  const elms: AnyCircuitElement[] = [
+    {
+      type: "pcb_solder_paste",
+      pcb_solder_paste_id: "paste1",
+      pcb_component_id: "pc1",
+      pcb_smtpad_id: "pad1",
+      layer: "top",
+      shape: "rect",
+      x: 1,
+      y: 0,
+      width: 0.3,
+      height: 1.5,
+    } as any,
+  ]
+
+  transformPCBElements(elms, compose(translate(10, 20), rotateDEG(90)))
+
+  const paste = elms[0] as any
+  expect(paste.x).toBeCloseTo(10)
+  expect(paste.y).toBeCloseTo(21)
+  expect(paste.width).toBe(1.5)
+  expect(paste.height).toBe(0.3)
+})
+
+test("transformPCBElements moves pcb_copper_text anchor_position", () => {
+  const elms: AnyCircuitElement[] = [
+    {
+      type: "pcb_copper_text",
+      pcb_copper_text_id: "ct1",
+      pcb_component_id: "pc1",
+      text: "GND",
+      anchor_position: { x: 1, y: 2 },
+      font: "tscircuit2024",
+      font_size: 1,
+      layer: "top",
+    } as any,
+  ]
+
+  transformPCBElements(elms, translate(5, 10))
+
+  const text = elms[0] as any
+  expect(text.anchor_position).toEqual({ x: 6, y: 12 })
+})
+
+test("transformPCBElements moves pcb_trace_hint route", () => {
+  const elms: AnyCircuitElement[] = [
+    {
+      type: "pcb_trace_hint",
+      pcb_trace_hint_id: "th1",
+      pcb_component_id: "pc1",
+      pcb_port_id: "pp1",
+      route: [
+        { x: 0, y: 0 },
+        { x: 1, y: 1, via: true },
+      ],
+    } as any,
+  ]
+
+  transformPCBElements(elms, translate(2, 3))
+
+  const hint = elms[0] as any
+  expect(hint.route[0].x).toBe(2)
+  expect(hint.route[0].y).toBe(3)
+  expect(hint.route[1].x).toBe(3)
+  expect(hint.route[1].y).toBe(4)
+  expect(hint.route[1].via).toBe(true)
+})
+
+test("transformPCBElements moves pcb_silkscreen_pill and pcb_silkscreen_oval centers", () => {
+  const elms: AnyCircuitElement[] = [
+    {
+      type: "pcb_silkscreen_pill",
+      pcb_silkscreen_pill_id: "spill1",
+      pcb_component_id: "pc1",
+      center: { x: 1, y: 2 },
+      width: 2,
+      height: 1,
+      layer: "top",
+    } as any,
+    {
+      type: "pcb_silkscreen_oval",
+      pcb_silkscreen_oval_id: "soval1",
+      pcb_component_id: "pc1",
+      center: { x: 3, y: 4 },
+      radius_x: 1,
+      radius_y: 0.5,
+      layer: "top",
+    } as any,
+  ]
+
+  transformPCBElements(elms, translate(5, 10))
+
+  expect((elms[0] as any).center).toEqual({ x: 6, y: 12 })
+  expect((elms[1] as any).center).toEqual({ x: 8, y: 14 })
+})


### PR DESCRIPTION
Fixes the root cause of tscircuit/core#2897 (grid/array layout repositions pads without transforming their solder paste).

## Root cause

`repositionPcbComponentTo` selects elements to move by `pcb_component_id` / `pcb_port_id` membership and hands them to `transformPCBElements`. But `transformPCBElement` had no branch for `pcb_solder_paste` (and a few other component-attached geometric types), so those elements were selected for the move and then silently returned untransformed — left at their pre-layout coordinates.

This is why core's grid layout (which routes through `repositionPcbComponentTo`) leaves paste behind while core's own `_setPositionFromLayout` / `_moveCircuitJsonElements` paths (which translate paste explicitly core-side) do not.

## What this changes

Adds the missing branches, matching the existing handling patterns:

| type | fields transformed | pattern matched |
|---|---|---|
| `pcb_solder_paste` | `x`/`y`, rect `width`/`height` swap on quarter-turns | same as `pcb_smtpad` |
| `pcb_copper_text` | `anchor_position` | same as `pcb_silkscreen_text` |
| `pcb_trace_hint` | `route` points | same as `pcb_trace` |
| `pcb_silkscreen_pill` / `pcb_silkscreen_oval` | `center` | same as `pcb_silkscreen_rect` |

These are the geometric types that carry `pcb_component_id` in circuit-json and are emitted by core today (paste from `SmtPad`, copper text from `CopperText`, hints from `TraceHint`); the remaining unhandled types are error/warning records with no geometry to move.

## Verification

- New tests fail on `main` (6 failures), pass with the fix; full suite 97/97.
- Reproduced tscircuit/core#2897 on core `main` (4 grid-arranged 0402s → all 8 pastes at pre-layout positions, 3.28 mm/2.82 mm displacement), then re-ran with this branch's build linked in: every paste lands exactly on its pad (Δ = 0.000 mm). Core needs no change of its own — just the dependency bump once this releases.
- `bun test`, `bunx tsc --noEmit`, `bun run format:check` all pass. (`package.json` is reformatted here because format-check was failing on `main` itself; drop that commit hunk if you'd rather keep it.)
