### PR TITLE
Follow insertion_direction rename to top/bottom

### DIFF
--- a/lib/get-bounds-of-pcb-elements.ts
+++ b/lib/get-bounds-of-pcb-elements.ts
@@ -227,10 +227,15 @@ export const getBoundsOfPcbElements = (
     } else if (elm.type === "pcb_trace") {
       for (const point of elm.route) {
         // TODO add trace thickness support
-        minX = Math.min(minX, point.x)
-        minY = Math.min(minY, point.y)
-        maxX = Math.max(maxX, point.x)
-        maxY = Math.max(maxY, point.y)
+        // "through_pad" route points describe a segment with start/end rather
+        // than a single x/y position.
+        const positions = "x" in point ? [point] : [point.start, point.end]
+        for (const { x, y } of positions) {
+          minX = Math.min(minX, x)
+          minY = Math.min(minY, y)
+          maxX = Math.max(maxX, x)
+          maxY = Math.max(maxY, y)
+        }
       }
     } else if (elm.type === "pcb_courtyard_outline") {
       for (const point of elm.outline) {

--- a/lib/transform-soup-elements.ts
+++ b/lib/transform-soup-elements.ts
@@ -1,4 +1,4 @@
-import type { AnyCircuitElement } from "circuit-json"
+import type { AnyCircuitElement, InsertionDirection } from "circuit-json"
 import { type Matrix, applyToPoint, decomposeTSR } from "transformation-matrix"
 import {
   directionToVec,
@@ -6,27 +6,20 @@ import {
   vecToDirection,
 } from "./direction-to-vec"
 
-type PcbInsertionDirection =
-  | "from_above"
-  | "from_left"
-  | "from_right"
-  | "from_front"
-  | "from_back"
-
 const getQuarterTurns = (angleRadians: number) =>
   Math.round(angleRadians / (Math.PI / 2))
 
 const insertionDirectionToVec = (
-  direction: Exclude<PcbInsertionDirection, "from_above">,
+  direction: Exclude<InsertionDirection, "from_above" | "from_below">,
 ) => {
   switch (direction) {
     case "from_left":
       return { x: -1, y: 0 }
     case "from_right":
       return { x: 1, y: 0 }
-    case "from_front":
+    case "from_top":
       return { x: 0, y: 1 }
-    case "from_back":
+    case "from_bottom":
       return { x: 0, y: -1 }
   }
 }
@@ -37,18 +30,26 @@ const vecToInsertionDirection = ({
 }: {
   x: number
   y: number
-}): Exclude<PcbInsertionDirection, "from_above"> => {
+}): Exclude<InsertionDirection, "from_above" | "from_below"> => {
   if (x > 0) return "from_right"
   if (x < 0) return "from_left"
-  if (y > 0) return "from_front"
-  return "from_back"
+  if (y > 0) return "from_top"
+  return "from_bottom"
 }
 
 export const transformInsertionDirection = (
-  direction: PcbInsertionDirection | undefined,
+  direction: InsertionDirection | undefined,
   opts: { rotationDegrees: number; isFlipped: boolean },
 ) => {
-  if (!direction || direction === "from_above") return direction
+  if (!direction) return direction
+
+  // Rotating within the board plane leaves a Z-axis insertion pointing along
+  // Z, but moving the part to the other layer reverses which side of the board
+  // the mating part approaches from.
+  if (direction === "from_above" || direction === "from_below") {
+    if (!opts.isFlipped) return direction
+    return direction === "from_above" ? "from_below" : "from_above"
+  }
 
   let { x, y } = insertionDirectionToVec(direction)
   let quarterTurns = Math.round(opts.rotationDegrees / 90)

--- a/lib/transform-soup-elements.ts
+++ b/lib/transform-soup-elements.ts
@@ -230,9 +230,22 @@ export const transformPCBElement = (elm: AnyCircuitElement, matrix: Matrix) => {
       p.y = tp.y
       return p
     })
+  } else if (elm.type === "pcb_trace") {
+    elm.route = elm.route.map((rp) => {
+      // "through_pad" route points describe a segment with start/end rather
+      // than a single x/y position.
+      if (!("x" in rp)) {
+        rp.start = applyToPoint(matrix, rp.start) as { x: number; y: number }
+        rp.end = applyToPoint(matrix, rp.end) as { x: number; y: number }
+        return rp
+      }
+      const tp = applyToPoint(matrix, rp) as { x: number; y: number }
+      rp.x = tp.x
+      rp.y = tp.y
+      return rp
+    })
   } else if (
     elm.type === "pcb_silkscreen_path" ||
-    elm.type === "pcb_trace" ||
     elm.type === "pcb_trace_hint" ||
     elm.type === "pcb_fabrication_note_path" ||
     elm.type === "pcb_note_path"

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "type": "module",
   "version": "0.0.102",
   "description": "Utility library for working with tscircuit circuit json",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "main": "dist/index.js",
   "scripts": {
     "test": "bun test",
@@ -28,12 +26,12 @@
     "@tscircuit/miniflex": "^0.0.4",
     "@types/bun": "^1.2.9",
     "bun-match-svg": "^0.0.15",
-    "circuit-json": "^0.0.418",
+    "circuit-json": "^0.0.461",
     "esbuild": "^0.20.2",
     "esbuild-register": "^3.5.0",
     "graphics-debug": "^0.0.95",
     "transformation-matrix": "^2.16.1",
-    "tscircuit": "^0.0.1474",
+    "tscircuit": "^0.0.2202",
     "tsup": "^8.0.2",
     "typescript": "^5.4.5",
     "zod": "^3.23.6"

--- a/tests/transform-pcb-elements.test.ts
+++ b/tests/transform-pcb-elements.test.ts
@@ -257,9 +257,9 @@ test("transformPCBElements moves pcb_note_line x1,y1,x2,y2", () => {
 
 test("transformPCBElements rotates pcb_component insertion_direction for 90/180/270 degree transforms", () => {
   const cases = [
-    { rotationDegrees: 90, expectedDirection: "from_front" },
+    { rotationDegrees: 90, expectedDirection: "from_top" },
     { rotationDegrees: 180, expectedDirection: "from_left" },
-    { rotationDegrees: 270, expectedDirection: "from_back" },
+    { rotationDegrees: 270, expectedDirection: "from_bottom" },
   ] as const
 
   for (const { rotationDegrees, expectedDirection } of cases) {
@@ -279,7 +279,7 @@ test("transformPCBElements mirrors pcb_component insertion_direction for flipped
   const elms: AnyCircuitElement[] = [
     createPcbComponent({
       pcb_component_id: "pc-front",
-      insertion_direction: "from_front",
+      insertion_direction: "from_top",
     }),
     createPcbComponent({
       pcb_component_id: "pc-left",
@@ -289,7 +289,7 @@ test("transformPCBElements mirrors pcb_component insertion_direction for flipped
 
   transformPCBElements(elms, compose(scale(1, -1)))
 
-  expect((elms[0] as PcbComponent).insertion_direction).toBe("from_back")
+  expect((elms[0] as PcbComponent).insertion_direction).toBe("from_bottom")
   expect((elms[1] as PcbComponent).insertion_direction).toBe("from_left")
 })
 
@@ -300,17 +300,29 @@ test("transformPCBElements applies rotation before Y-mirror for pcb_component in
 
   transformPCBElements(elms, compose(scale(1, -1), rotateDEG(90)))
 
-  expect((elms[0] as PcbComponent).insertion_direction).toBe("from_front")
+  expect((elms[0] as PcbComponent).insertion_direction).toBe("from_top")
 })
 
-test('transformPCBElements keeps pcb_component insertion_direction "from_above" unchanged', () => {
+test('transformPCBElements keeps pcb_component insertion_direction "from_above" unchanged under rotation', () => {
   const elms: AnyCircuitElement[] = [
     createPcbComponent({ insertion_direction: "from_above" }),
   ]
 
-  transformPCBElements(elms, compose(scale(1, -1), rotateDEG(90)))
+  transformPCBElements(elms, rotateDEG(90))
 
   expect((elms[0] as PcbComponent).insertion_direction).toBe("from_above")
+})
+
+test("transformPCBElements flips Z insertion_direction for mirrored transforms", () => {
+  const elms: AnyCircuitElement[] = [
+    createPcbComponent({ insertion_direction: "from_above" }),
+    createPcbComponent({ insertion_direction: "from_below" }),
+  ]
+
+  transformPCBElements(elms, compose(scale(1, -1), rotateDEG(90)))
+
+  expect((elms[0] as PcbComponent).insertion_direction).toBe("from_below")
+  expect((elms[1] as PcbComponent).insertion_direction).toBe("from_above")
 })
 
 test("transformPCBElements moves pcb_component cable_insertion_center", () => {


### PR DESCRIPTION
Circuit JSON renamed the +/-Y insertion directions from "from_front"/"from_back" to "from_top"/"from_bottom" and added "from_below" (-Z).

The local PcbInsertionDirection union is replaced with Circuit JSON's exported InsertionDirection so this transform cannot silently drift from the schema again; previously it could have written a value the schema no longer accepts.

Mirrored transforms now also flip the Z-axis directions. "from_above" was returned unchanged for any transform, which had no better answer available while "from_below" did not exist.