### PR TITLE
Add semantic PCB pin 1 location analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ It reduces the amount of code to retrieve or join elements from circuit json, it
 | `getElementRenderLayers` | [`lib/get-element-render-layers.ts`](./lib/get-element-render-layers.ts) | Returns schematic/PCB render layers used for an element. |
 | `computeClearanceBetweenElements` | [`lib/compute-clearance-between-elements.ts`](./lib/compute-clearance-between-elements.ts) | Computes the minimum edge-to-edge clearance between two circuit elements using geometric decomposition. |
 | `computeGapBetweenCopper` | [`lib/compute-gap-between-copper.ts`](./lib/compute-gap-between-copper.ts) | Computes the minimum copper-to-copper gap between two circuit elements by decomposing them into primitive shapes. |
+| `analyzePcbPin1Location` | [`lib/analyze-pcb-pin1-location.ts`](./lib/analyze-pcb-pin1-location.ts) | Infers a semantic pin 1 location from PCB pad geometry and numeric port hints. |
 | `categorizeErrorOrWarning` | [`lib/categorize-error-or-warning.ts`](./lib/categorize-error-or-warning.ts) | Categorizes DRC error/warning types into `"netlist"`, `"pin_specification"`, `"placement"`, `"routing"`, or `"unknown"`. |
 
 ## Standard Usage

--- a/index.ts
+++ b/index.ts
@@ -23,6 +23,7 @@ export * from "./lib/get-element-render-layers"
 export * from "./lib/compute-gap-between-copper"
 export * from "./lib/compute-clearance-between-elements"
 export * from "./lib/shape-distances/distance-between-shapes"
+export * from "./lib/analyze-pcb-pin1-location"
 
 export {
   transformPCBElement as transformPcbElement,

--- a/lib/analyze-pcb-pin1-location.ts
+++ b/lib/analyze-pcb-pin1-location.ts
@@ -1,0 +1,149 @@
+import type { PcbPin1Location } from "circuit-json"
+
+type Point = { x: number; y: number }
+
+export interface PcbPin1LocationElement {
+  type: string
+  x?: number
+  y?: number
+  points?: readonly Point[]
+  port_hints?: readonly unknown[]
+}
+
+type Pin1Side = "leftside" | "rightside" | "topside" | "bottomside"
+type Pin1Alignment = "left" | "right" | "top" | "bottom"
+
+const PIN1_LOCATION_PARTS = {
+  leftside_top: { side: "leftside", alignment: "top" },
+  leftside_bottom: { side: "leftside", alignment: "bottom" },
+  rightside_top: { side: "rightside", alignment: "top" },
+  rightside_bottom: { side: "rightside", alignment: "bottom" },
+  topside_left: { side: "topside", alignment: "left" },
+  topside_right: { side: "topside", alignment: "right" },
+  bottomside_left: { side: "bottomside", alignment: "left" },
+  bottomside_right: { side: "bottomside", alignment: "right" },
+} as const satisfies Record<
+  PcbPin1Location,
+  { side: Pin1Side; alignment: Pin1Alignment }
+>
+
+const PIN1_LOCATIONS = Object.keys(PIN1_LOCATION_PARTS) as PcbPin1Location[]
+
+const getPadCenter = (pad: PcbPin1LocationElement): Point | null => {
+  if (typeof pad.x === "number" && typeof pad.y === "number") {
+    return { x: pad.x, y: pad.y }
+  }
+
+  if (pad.points && pad.points.length > 0) {
+    const xs = pad.points.map((point) => point.x)
+    const ys = pad.points.map((point) => point.y)
+    return {
+      x: (Math.min(...xs) + Math.max(...xs)) / 2,
+      y: (Math.min(...ys) + Math.max(...ys)) / 2,
+    }
+  }
+
+  return null
+}
+
+const getPinNumber = (pad: PcbPin1LocationElement): number | null => {
+  for (const hint of pad.port_hints ?? []) {
+    const match = String(hint)
+      .trim()
+      .match(/^(?:pin)?(\d+)$/i)
+    if (match) return Number.parseInt(match[1]!, 10)
+  }
+  return null
+}
+
+const pinMatchesLocation = (
+  padCenters: Point[],
+  pin1Center: Point,
+  pin1Location: PcbPin1Location,
+) => {
+  const xs = padCenters.map((point) => point.x)
+  const ys = padCenters.map((point) => point.y)
+  const minX = Math.min(...xs)
+  const maxX = Math.max(...xs)
+  const minY = Math.min(...ys)
+  const maxY = Math.max(...ys)
+  const centerX = (minX + maxX) / 2
+  const centerY = (minY + maxY) / 2
+  const spanX = maxX - minX
+  const spanY = maxY - minY
+  const tolerance = Math.max(spanX, spanY, 1) * 1e-6
+  const { side, alignment } = PIN1_LOCATION_PARTS[pin1Location]
+
+  const onRequestedSide =
+    (side === "leftside" && Math.abs(pin1Center.x - minX) <= tolerance) ||
+    (side === "rightside" && Math.abs(pin1Center.x - maxX) <= tolerance) ||
+    (side === "topside" && Math.abs(pin1Center.y - maxY) <= tolerance) ||
+    (side === "bottomside" && Math.abs(pin1Center.y - minY) <= tolerance)
+
+  const atRequestedAlignment =
+    (alignment === "left" &&
+      (spanX <= tolerance || pin1Center.x < centerX - tolerance)) ||
+    (alignment === "right" &&
+      (spanX <= tolerance || pin1Center.x > centerX + tolerance)) ||
+    (alignment === "top" &&
+      (spanY <= tolerance || pin1Center.y > centerY + tolerance)) ||
+    (alignment === "bottom" &&
+      (spanY <= tolerance || pin1Center.y < centerY - tolerance))
+
+  return onRequestedSide && atRequestedAlignment
+}
+
+/**
+ * Infers the semantic pin 1 location from PCB pad positions and numeric port
+ * hints. Returns null when pin 1 is missing or the geometry cannot distinguish
+ * a rotation from a reflection.
+ */
+export const analyzePcbPin1Location = (
+  elements: readonly PcbPin1LocationElement[],
+): PcbPin1Location | null => {
+  const pads = elements.filter(
+    (element) =>
+      element.type === "pcb_smtpad" || element.type === "pcb_plated_hole",
+  )
+  const numberedPads = pads.map((pad) => ({
+    center: getPadCenter(pad),
+    pinNumber: getPinNumber(pad),
+  }))
+  const pin1Center = numberedPads.find((pad) => pad.pinNumber === 1)?.center
+  const padCenters = numberedPads
+    .map((pad) => pad.center)
+    .filter((point) => point !== null)
+  if (!pin1Center || padCenters.length === 0) return null
+
+  const candidates = PIN1_LOCATIONS.filter((pin1Location) =>
+    pinMatchesLocation(padCenters, pin1Center, pin1Location),
+  )
+  if (candidates.length === 1) return candidates[0]!
+  if (candidates.length === 0) return null
+
+  let nextNumberedPad: { center: Point; pinNumber: number } | undefined
+  for (const pad of numberedPads) {
+    if (!pad.center || pad.pinNumber === null || pad.pinNumber <= 1) continue
+    if (!nextNumberedPad || pad.pinNumber < nextNumberedPad.pinNumber) {
+      nextNumberedPad = { center: pad.center, pinNumber: pad.pinNumber }
+    }
+  }
+  if (!nextNumberedPad) return null
+
+  const xs = padCenters.map((point) => point.x)
+  const ys = padCenters.map((point) => point.y)
+  const span = Math.max(
+    Math.max(...xs) - Math.min(...xs),
+    Math.max(...ys) - Math.min(...ys),
+    1,
+  )
+  const tolerance = span * 1e-6
+  const topologyCandidates = candidates.filter((pin1Location) => {
+    const { side } = PIN1_LOCATION_PARTS[pin1Location]
+    return side === "leftside" || side === "rightside"
+      ? Math.abs(nextNumberedPad.center.x - pin1Center.x) <= tolerance
+      : Math.abs(nextNumberedPad.center.y - pin1Center.y) <= tolerance
+  })
+
+  return topologyCandidates.length === 1 ? topologyCandidates[0]! : null
+}

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "type": "module",
   "version": "0.0.103",
   "description": "Utility library for working with tscircuit circuit json",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "main": "dist/index.js",
   "scripts": {
     "test": "bun test",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@tscircuit/miniflex": "^0.0.4",
     "@types/bun": "^1.2.9",
     "bun-match-svg": "^0.0.15",
-    "circuit-json": "^0.0.461",
+    "circuit-json": "^0.0.464",
     "esbuild": "^0.20.2",
     "esbuild-register": "^3.5.0",
     "graphics-debug": "^0.0.95",

--- a/tests/analyze-pcb-pin1-location.test.ts
+++ b/tests/analyze-pcb-pin1-location.test.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement, PcbPin1Location } from "circuit-json"
+import { analyzePcbPin1Location } from "../lib/analyze-pcb-pin1-location"
+
+type RightAngleRotation = 0 | 90 | 180 | 270
+
+const createPad = (pinNumber: number, x: number, y: number) =>
+  ({
+    type: "pcb_smtpad",
+    shape: "rect",
+    pcb_smtpad_id: `pcb_smtpad_${pinNumber}`,
+    x,
+    y,
+    width: 0.5,
+    height: 1,
+    layer: "top",
+    port_hints: [`pin${pinNumber}`],
+  }) as AnyCircuitElement
+
+const rotatePads = (pads: AnyCircuitElement[], rotation: RightAngleRotation) =>
+  pads.map((pad) => {
+    if (!("x" in pad) || !("y" in pad)) return pad
+    const { x, y } = pad
+    const center =
+      rotation === 90
+        ? { x: -y, y: x }
+        : rotation === 180
+          ? { x: -x, y: -y }
+          : rotation === 270
+            ? { x: y, y: -x }
+            : { x, y }
+    return { ...pad, ...center }
+  })
+
+const clockwisePinOrder = [
+  createPad(1, -1, 1),
+  createPad(2, -1, -1),
+  createPad(3, 1, -1),
+  createPad(4, 1, 1),
+]
+const counterClockwisePinOrder = [
+  createPad(1, -1, 1),
+  createPad(2, 1, 1),
+  createPad(3, 1, -1),
+  createPad(4, -1, -1),
+]
+
+const cases: Array<{
+  pads: AnyCircuitElement[]
+  rotation: RightAngleRotation
+  expected: PcbPin1Location
+}> = [
+  { pads: clockwisePinOrder, rotation: 0, expected: "leftside_top" },
+  { pads: clockwisePinOrder, rotation: 90, expected: "bottomside_left" },
+  { pads: clockwisePinOrder, rotation: 180, expected: "rightside_bottom" },
+  { pads: clockwisePinOrder, rotation: 270, expected: "topside_right" },
+  { pads: counterClockwisePinOrder, rotation: 0, expected: "topside_left" },
+  {
+    pads: counterClockwisePinOrder,
+    rotation: 90,
+    expected: "leftside_bottom",
+  },
+  {
+    pads: counterClockwisePinOrder,
+    rotation: 180,
+    expected: "bottomside_right",
+  },
+  {
+    pads: counterClockwisePinOrder,
+    rotation: 270,
+    expected: "rightside_top",
+  },
+]
+
+test("analyzes all semantic pin 1 locations", () => {
+  for (const { pads, rotation, expected } of cases) {
+    expect(analyzePcbPin1Location(rotatePads(pads, rotation))).toBe(expected)
+  }
+})
+
+test("returns null for ambiguous linear footprints and missing pin 1", () => {
+  expect(
+    analyzePcbPin1Location([createPad(1, -1, 0), createPad(2, 1, 0)]),
+  ).toBeNull()
+  expect(
+    analyzePcbPin1Location([createPad(2, -1, 0), createPad(3, 1, 0)]),
+  ).toBeNull()
+})


### PR DESCRIPTION
## Summary

- add `analyzePcbPin1Location` to infer semantic pin 1 orientation from Circuit JSON pad geometry and numeric port hints
- return the canonical `PcbPin1Location` string values introduced in `circuit-json@0.0.464`
- use the next numbered pad to distinguish rotation-compatible corner locations from reflected topology
- preserve `null` for missing or genuinely ambiguous pin 1 geometry
- document and export the new utility

This replaces the Footprinter-specific implementation from tscircuit/footprinter#763 so the analysis lives with other Circuit JSON geometry utilities.

## Testing

- all eight semantic pin 1 locations
- ambiguous two-pin linear footprints and missing pin 1
- full test suite: 100 tests
- `bunx tsc --noEmit`
- `bun run build`
- Biome check on changed files
- manual cross-check against EasyEDA converter fixtures for DIP, SOIC, QFN, USB-C, and multi-row packages
